### PR TITLE
Use 96G RAM for Cromwell's java heap

### DIFF
--- a/wdl_runner/cromwell_driver.py
+++ b/wdl_runner/cromwell_driver.py
@@ -40,7 +40,7 @@ class CromwellDriver(object):
     self.cromwell_proc = subprocess.Popen([
         'java',
         '-Dconfig.file=' + self.cromwell_conf,
-        '-Xmx4g',
+        '-Xmx96g',
         '-jar', self.cromwell_jar,
         'server'])
 


### PR DESCRIPTION
In response to Java crashing with ~600 simultaneous jobs using 4GB heap, and plans for thousands of jobs, first pass attempt is increasing the java heap. In the future, may need to actually stand up a Cromwell server backed by SQL, but would like to avoid that if possible.